### PR TITLE
Update to Freedesktop SDK 21.08

### DIFF
--- a/net.xmind.XMind8.yml
+++ b/net.xmind.XMind8.yml
@@ -1,6 +1,6 @@
 id: net.xmind.XMind8
 runtime: org.freedesktop.Platform
-runtime-version: '19.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk8


### PR DESCRIPTION
The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021.